### PR TITLE
allow accessing interfaces before setting a config

### DIFF
--- a/usb.js
+++ b/usb.js
@@ -36,7 +36,6 @@ usb.Device.prototype.timeout = 1000
 
 usb.Device.prototype.open = function(defaultConfig){
 	this.__open()
-	if (defaultConfig === false) return
 	this.interfaces = []
 	var len = this.configDescriptor ? this.configDescriptor.interfaces.length : 0
 	for (var i=0; i<len; i++){


### PR DESCRIPTION
Hi! I'm porting a library that needs to access interfaces (to detach kernel drivers, etc) before calling `device.setConfiguration()`.
`usb` currently doesn't make that possible... I'd suggest a fix like this one.