### PR TITLE
Define properties as configurable, eliminating errors if library is reloaded

### DIFF
--- a/usb.js
+++ b/usb.js
@@ -58,7 +58,8 @@ Object.defineProperty(usb.Device.prototype, "configDescriptor", {
 			if (e.errno == usb.LIBUSB_ERROR_NOT_FOUND) return null;
 			throw e;
 		}
-	}
+	},
+	configurable: true
 });
 
 Object.defineProperty(usb.Device.prototype, "allConfigDescriptors", {
@@ -70,13 +71,15 @@ Object.defineProperty(usb.Device.prototype, "allConfigDescriptors", {
 			if (e.errno == usb.LIBUSB_ERROR_NOT_FOUND) return [];
 			throw e;
 		}
-	}
+	},
+	configurable: true
 });
 
 Object.defineProperty(usb.Device.prototype, "parent", {
 	get: function() {
 		return this._parent || (this._parent = this.__getParent())
-	}
+	},
+	configurable: true
 });
 
 usb.Device.prototype.interface = function(addr){


### PR DESCRIPTION
The Jest test runner with --runInBand option enabled runs all tests in a single thread rather than creating a worker pool of child processes. This is essential when testing with node-usb otherwise tests fail randomly as they contend for interfaces and endpoints.

Unfortunately, setting --runInBand causes node-usb to reload in the same process multiple times, once for every test module. And if strict mode is turned on, repeated calls to Object.defineProperty() cause TypeError's to be thrown. This is because the current implementation marks the created properties as non-configurable.

The fix in this pull request is straightforward - simply mark each of the defined properties as configurable, allowing them to update and eliminating the TypeError.