### PR TITLE
Throw if error during initialize()

### DIFF
--- a/tsc/webusb/webusb-device.ts
+++ b/tsc/webusb/webusb-device.ts
@@ -401,7 +401,7 @@ export class WebUSBDevice implements USBDevice {
             this.serialNumber = await this.getStringDescriptor(this.device.deviceDescriptor.iSerialNumber);
             this.configurations = await this.getConfigurations();
         } catch (error) {
-        	throw new Error(`initialize error: ${error}`);
+            throw new Error(`initialize error: ${error}`);
         } finally {
             if (this.opened) {
                 this.device.close();

--- a/tsc/webusb/webusb-device.ts
+++ b/tsc/webusb/webusb-device.ts
@@ -400,6 +400,8 @@ export class WebUSBDevice implements USBDevice {
             this.productName = await this.getStringDescriptor(this.device.deviceDescriptor.iProduct);
             this.serialNumber = await this.getStringDescriptor(this.device.deviceDescriptor.iSerialNumber);
             this.configurations = await this.getConfigurations();
+        } catch (error) {
+        	throw new Error(`initialize error: ${error}`);
         } finally {
             if (this.opened) {
                 this.device.close();


### PR DESCRIPTION
When there are any errors during `initialize()`, it currently silently fails and returns empty. This can be problematic if there are "access denied" errors when for example udev rules aren't set properly on Linux. Having `initialize()` throw the error would be really helpful in these instances.