### PR TITLE
getStringDescriptor 0 returns null

### DIFF
--- a/test/usb.coffee
+++ b/test/usb.coffee
@@ -70,6 +70,12 @@ describe 'Device', ->
 			assert.equal(s, 'Nonolith Labs')
 			done()
 
+	it 'supports null string descriptors', (done) ->
+		device.getStringDescriptor device.configDescriptor.iConfiguration, (e, s) ->
+			assert.ok(e == undefined, e)
+			assert.equal(s, undefined)
+			done()
+
 	describe 'control transfer', ->
 		b = Buffer.from([0x30...0x40])
 		it 'should OUT transfer when the IN bit is not set', (done) ->

--- a/tsc/usb/device.ts
+++ b/tsc/usb/device.ts
@@ -203,6 +203,12 @@ export class ExtendedDevice {
      * @param callback
      */
     public getStringDescriptor(this: usb.Device, desc_index: number, callback: (error?: usb.LibUSBException, value?: string) => void): void {
+        // Index 0 indicates null
+        if (desc_index === 0) {
+            callback();
+            return;
+        }
+
         const langid = 0x0409;
         const length = 255;
         this.controlTransfer(


### PR DESCRIPTION
Shortcut `getStringDescriptor()` to return undefined when passed index 0.

Fixes #475 