### PR TITLE
Fix libusb_set_option deprecation

### DIFF
--- a/src/node_usb.cc
+++ b/src/node_usb.cc
@@ -117,7 +117,7 @@ Napi::Value SetDebugLevel(const Napi::CallbackInfo& info) {
 		THROW_BAD_ARGS("Usb::SetDebugLevel argument is invalid. [uint:[0-4]]!")
 	}
 
-	libusb_set_debug(usb_context, info[0].As<Napi::Number>().Int32Value());
+	libusb_set_option(usb_context, LIBUSB_OPTION_LOG_LEVEL, info[0].As<Napi::Number>().Int32Value());
 	return env.Undefined();
 }
 


### PR DESCRIPTION
## Changes
<!-- Describe the changes this PR introduces -->
-

## Fixes
<!-- List the GitHub issues this PR resolves -->
-

## Checklist
<!-- Put an `x` in the boxes that apply -->
Have you...

- [ ] Tested the change acts as expected
- [ ] Checked the change doesn't remove or change existing functionality
- [ ] Considered how the feature impacts the product and tested around it (not just the happy paths)
- [ ] Where possible, executed the hardware tests on multiple operating systems
