### PR TITLE
chore: remove unused header

### DIFF
--- a/src/node_usb.h
+++ b/src/node_usb.h
@@ -10,9 +10,9 @@
 #endif
 
 #include <thread>
+#include <atomic>
 #include <libusb.h>
 #include <napi.h>
-#include <node_buffer.h>
 
 #include "helpers.h"
 #include "uv_async_queue.h"


### PR DESCRIPTION
## Changes
<!-- Describe the changes this PR introduces -->
- `node_buffer.h` is not a node-api header, and its contents do not follow the node-api stability guarantees https://nodejs.org/api/n-api.html#implications-of-abi-stability.
  After removing the header, it still compiles so it appears that nothing from it was being used

## Fixes
<!-- List the GitHub issues this PR resolves -->
-

## Checklist
<!-- Put an `x` in the boxes that apply -->
Have you...

- [x] Tested the change acts as expected
- [x] Checked the change doesn't remove or change existing functionality
- [x] Considered how the feature impacts the product and tested around it (not just the happy paths)
- [ ] Where possible, executed the hardware tests on multiple operating systems
