### PR TITLE
fix: windows hotplug cmNotifyFilter access violation #540

### DIFF
--- a/src/hotplug/windows.cc
+++ b/src/hotplug/windows.cc
@@ -78,6 +78,7 @@ DWORD MyCMInterfaceNotification(HCMNOTIFICATION hNotify, PVOID Context, CM_NOTIF
 
 class HotPlugManagerWindows : public HotPlugManager
 {
+public:
     HotPlugManagerWindows()
     {
         cmNotifyFilter = { 0 };

--- a/src/hotplug/windows.cc
+++ b/src/hotplug/windows.cc
@@ -78,6 +78,15 @@ DWORD MyCMInterfaceNotification(HCMNOTIFICATION hNotify, PVOID Context, CM_NOTIF
 
 class HotPlugManagerWindows : public HotPlugManager
 {
+    HotPlugManagerWindows()
+    {
+        cmNotifyFilter = { 0 };
+        cmNotifyFilter.cbSize = sizeof(cmNotifyFilter);
+        cmNotifyFilter.Flags = 0;
+        cmNotifyFilter.FilterType = CM_NOTIFY_FILTER_TYPE_DEVICEINTERFACE;
+        cmNotifyFilter.u.DeviceInterface.ClassGuid = GUID_DEVINTERFACE_USB_DEVICE;
+    }
+    
     int supportedHotplugEvents()
     {
         return HOTPLUG_SUPPORTS_IDS;
@@ -91,12 +100,6 @@ class HotPlugManagerWindows : public HotPlugManager
         }
 
         isRunning = true;
-
-        CM_NOTIFY_FILTER cmNotifyFilter = { 0 };
-        cmNotifyFilter.cbSize = sizeof(cmNotifyFilter);
-        cmNotifyFilter.Flags = 0;
-        cmNotifyFilter.FilterType = CM_NOTIFY_FILTER_TYPE_DEVICEINTERFACE;
-        cmNotifyFilter.u.DeviceInterface.ClassGuid = GUID_DEVINTERFACE_USB_DEVICE;
     
         auto res = CM_Register_Notification(&cmNotifyFilter, (PVOID)instanceData, (PCM_NOTIFY_CALLBACK)&MyCMInterfaceNotification, &hcm);
         if (res != CR_SUCCESS)
@@ -121,6 +124,7 @@ class HotPlugManagerWindows : public HotPlugManager
 private:
     std::atomic<bool> isRunning = {false};
     HCMNOTIFICATION hcm;
+    CM_NOTIFY_FILTER cmNotifyFilter;
 };
 
 std::unique_ptr<HotPlugManager> HotPlugManager::create()


### PR DESCRIPTION
## Changes
<!-- Describe the changes this PR introduces -->
- Ensure cmNotifyFilter is kept alive for the duration of the hotplug detetion

## Fixes
<!-- List the GitHub issues this PR resolves -->
- #540

## Checklist
<!-- Put an `x` in the boxes that apply -->
Have you...

- [ ] Tested the change acts as expected
- [x] Checked the change doesn't remove or change existing functionality
- [x] Considered how the feature impacts the product and tested around it (not just the happy paths)
- [ ] Where possible, executed the hardware tests on multiple operating systems
