### PR TITLE
Update bindings to include Endpoints and update node-gyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@types/w3c-web-usb": "1.0.6",
     "node-addon-api": "^4.2.0",
-    "node-gyp-build": "^4.3.0"
+    "node-gyp-build": "^4.5.0"
   },
   "devDependencies": {
     "@types/node": "^14.14.41",
@@ -63,7 +63,7 @@
     "coffeescript": "^2.5.1",
     "eslint": "^7.29.0",
     "mocha": "^9.1.3",
-    "node-gyp": "^7.1.2",
+    "node-gyp": "^9.1.0",
     "prebuildify": "^4.2.1",
     "prebuildify-ci": "^1.0.5",
     "prebuildify-cross": "^4.0.1",


### PR DESCRIPTION
## Changes
- Update node-gyp to a more recent version, this is required for installing on newer version of Windows. This allows use to use python3+ and MSVS 2022.
- Extending the bindings to include `Endpoint`, `InEndpoint` and `OutEndpoint`. This is required to properly use these types in ts.

## Checklist

- [x] Tested the change acts as expected
- [x] Checked the change doesn't remove or change existing functionality
- [x] Considered how the feature impacts the product and tested around it (not just the happy paths)
- [x] Where possible, executed the hardware tests on multiple operating systems

I have tested this across Windows 10, 11 and on my Linux ubuntu box locally. Annoyingly `npm install` has broken usage with submodules for quiet a while. So all of these had been doing using `npm link` locally after properly updating the submodule manually.