### PR TITLE
Fix #548 allow multiple polling to fail.

### DIFF
--- a/tsc/usb/endpoint.ts
+++ b/tsc/usb/endpoint.ts
@@ -103,7 +103,9 @@ export class InEndpoint extends Endpoint {
                 this.emit('data', buffer.slice(0, actualLength));
             } else if (error.errno != LIBUSB_TRANSFER_CANCELLED) {
                 this.emit('error', error);
-                this.stopPoll();
+                if (this.pollActive) {
+                    this.stopPoll();
+                }
             }
 
             if (this.pollActive) {


### PR DESCRIPTION
Allow multiple transfers to emit errors,
however only attempt to stop polling if
the polling is currently active.


## Fixes
- #548 

## Checklist
- [x] Tested the change acts as expected
- [x] Checked the change doesn't remove or change existing functionality
- [x] Considered how the feature impacts the product and tested around it (not just the happy paths)
- [x] Where possible, executed the hardware tests on multiple operating systems
