### PR TITLE
Allow forcing hotplug poll loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,12 @@ Legacy usb object.
 #### usb.LIBUSB_*
 Constant properties from libusb
 
+#### usb.getDeviceList()
+Return a list of legacy `Device` objects for the USB devices attached to the system.
+
+#### usb.pollHotplug
+Force polling loop for hotplug events.
+
 #### usb.setDebugLevel(level : int)
 Set the libusb debug level (between 0 and 4)
 

--- a/tsc/usb/bindings.ts
+++ b/tsc/usb/bindings.ts
@@ -14,6 +14,11 @@ module.exports = usb;
  */
 export declare function getDeviceList(): Device[];
 
+/**
+ * Force polling loop for hotplug events
+ */
+export declare let pollHotplug: boolean;
+
 export declare const INIT_ERROR: number;
 
 export declare class LibUSBException extends Error {


### PR DESCRIPTION
## Changes
<!-- Describe the changes this PR introduces -->
- Introduce `pollHotplug` setting to force polling of devices for hotplug events

## Fixes
<!-- List the GitHub issues this PR resolves -->
- Works around the issue described in https://github.com/node-usb/node-usb/issues/540

## Checklist
<!-- Put an `x` in the boxes that apply -->
Have you...

- [x] Tested the change acts as expected
- [x] Checked the change doesn't remove or change existing functionality
- [x] Considered how the feature impacts the product and tested around it (not just the happy paths)
- [x] Where possible, executed the hardware tests on multiple operating systems
