### PR TITLE
Add delay to devices events

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "postcompile": "eslint . --ext .ts",
     "watch": "tsc -w --preserveWatchOutput",
     "test": "mocha --require coffeescript/register --grep Module test/*",
-    "full-test": "mocha --require coffeescript/register test/*.coffee",
+    "full-test": "mocha --timeout 10000 --require coffeescript/register test/*.coffee",
     "valgrind": "coffee -c test/*.coffee; valgrind --leak-check=full --show-possibly-lost=no node --expose-gc --trace-gc node_modules/mocha/bin/_mocha -R spec",
     "docs": "typedoc",
     "prebuild": "prebuildify --napi --strip",

--- a/test/usb.coffee
+++ b/test/usb.coffee
@@ -41,9 +41,24 @@ describe 'findByIds', ->
         assert.ok(dev, "Demo device is not attached")
 
 describe 'findBySerialNumber', ->
-    it 'should return a single device ', ->
+    it 'should return a single device', ->
         dev = findBySerialNumber('TEST_DEVICE')
         assert.ok(dev, "Demo device is not attached")
+
+describe 'Hotplug', ->
+    it 'should detect detach', (done) ->
+        usb.once 'detach', (d) ->
+            assert.equal(d.deviceDescriptor.idVendor, 0x59e3)
+            assert.equal(d.deviceDescriptor.idProduct, 0x0a23)
+            done()
+        console.log('Disconnect device now...')
+
+    it 'should detect attach', (done) ->
+        usb.once 'attach', (d) ->
+            assert.equal(d.deviceDescriptor.idVendor, 0x59e3)
+            assert.equal(d.deviceDescriptor.idProduct, 0x0a23)
+            done()
+        console.log('Connect device now...')
 
 describe 'Device', ->
     device = null

--- a/test/webusb.coffee
+++ b/test/webusb.coffee
@@ -35,6 +35,19 @@ describe 'getDevices', ->
         assert.notEqual(l[0], undefined)
         assert.deepEqual(l[0], device)
 
+describe 'WebUSB Hotplug', ->
+    it 'should detect connect', (done) ->
+        webusb.addEventListener 'disconnect', (e) ->
+            assert.equal(e.device.serialNumber, "TEST_DEVICE")
+            done()
+        console.log('Disconnect device now...')
+
+    it 'should detect disconnect', (done) ->
+        webusb.addEventListener 'connect', (e) ->
+            assert.equal(e.device.serialNumber, "TEST_DEVICE")
+            done()
+        console.log('Connect device now...')
+
 describe 'Device properties', ->
     device = null
     before ->

--- a/test/webusb.coffee
+++ b/test/webusb.coffee
@@ -36,16 +36,20 @@ describe 'getDevices', ->
         assert.deepEqual(l[0], device)
 
 describe 'WebUSB Hotplug', ->
-    it 'should detect connect', (done) ->
-        webusb.addEventListener 'disconnect', (e) ->
+    it 'should detect disconnect', (done) ->
+        fn = (e) ->
             assert.equal(e.device.serialNumber, "TEST_DEVICE")
+            webusb.removeEventListener 'disconnect', fn
             done()
+        webusb.addEventListener 'disconnect', fn
         console.log('Disconnect device now...')
 
-    it 'should detect disconnect', (done) ->
-        webusb.addEventListener 'connect', (e) ->
+    it 'should detect connect', (done) ->
+        fn = (e) ->
             assert.equal(e.device.serialNumber, "TEST_DEVICE")
+            webusb.removeEventListener 'connect', fn
             done()
+        webusb.addEventListener 'connect', fn
         console.log('Connect device now...')
 
 describe 'Device properties', ->

--- a/tsc/usb/bindings.ts
+++ b/tsc/usb/bindings.ts
@@ -19,6 +19,11 @@ export declare function getDeviceList(): Device[];
  */
 export declare let pollHotplug: boolean;
 
+/**
+ * Hotplug polling loop delay (ms)
+ */
+export declare let pollHotplugDelay: number;
+
 export declare const INIT_ERROR: number;
 
 export declare class LibUSBException extends Error {

--- a/tsc/usb/index.ts
+++ b/tsc/usb/index.ts
@@ -13,6 +13,11 @@ Object.defineProperty(usb, 'pollHotplug', {
     writable: true
 });
 
+Object.defineProperty(usb, 'pollHotplugDelay', {
+    value: 500,
+    writable: true
+});
+
 Object.getOwnPropertyNames(ExtendedDevice.prototype).forEach(name => {
     Object.defineProperty(usb.Device.prototype, name, Object.getOwnPropertyDescriptor(ExtendedDevice.prototype, name) || Object.create(null));
 });
@@ -87,8 +92,11 @@ const pollHotplug = (start = false) => {
         emitHotplugEvents();
     }
 
-    setTimeout(() => pollHotplug(), 500);
+    setTimeout(() => pollHotplug(), usb.pollHotplugDelay);
 };
+
+// Devices changed event handler
+const devicesChanged = () => setTimeout(() => emitHotplugEvents(), usb.pollHotplugDelay);
 
 // Hotplug control
 let hotplugSupported = 0;
@@ -106,8 +114,8 @@ const startHotplug = () => {
 
         if (hotplugSupported === 2) {
             // Use hotplug ID events to trigger a change check
-            usb.on('attachIds', emitHotplugEvents);
-            usb.on('detachIds', emitHotplugEvents);
+            usb.on('attachIds', devicesChanged);
+            usb.on('detachIds', devicesChanged);
         }
     } else {
         // Fallback to using polling to check for changes
@@ -122,8 +130,8 @@ const stopHotplug = () => {
 
         if (hotplugSupported === 2) {
             // Remove hotplug ID event listeners
-            usb.off('attachIds', emitHotplugEvents);
-            usb.off('detachIds', emitHotplugEvents);
+            usb.off('attachIds', devicesChanged);
+            usb.off('detachIds', devicesChanged);
         }
     } else {
         // Stop polling


### PR DESCRIPTION
## Changes
<!-- Describe the changes this PR introduces -->
- Add a delay after receiving device changed events on Windows
- Added hotplug connect/disconnect event hardware tests for legacy API and WebUSB API

## Fixes
<!-- List the GitHub issues this PR resolves -->
- Short-term fix for #540 

## Checklist
<!-- Put an `x` in the boxes that apply -->
Have you...

- [x] Tested the change acts as expected
- [x] Checked the change doesn't remove or change existing functionality
- [x] Considered how the feature impacts the product and tested around it (not just the happy paths)
- [x] Where possible, executed the hardware tests on multiple operating systems
