### PR TITLE
fix: hotplug crash with x86 windows

### DIFF
--- a/src/hotplug/windows.cc
+++ b/src/hotplug/windows.cc
@@ -54,7 +54,7 @@ void extractVidPid(wchar_t *buf, int *vid, int *pid)
     }
 }
 
-DWORD MyCMInterfaceNotification(HCMNOTIFICATION hNotify, PVOID Context, CM_NOTIFY_ACTION Action, PCM_NOTIFY_EVENT_DATA EventData, DWORD EventDataSize)
+DWORD WINAPI MyCMInterfaceNotification(HCMNOTIFICATION hNotify, PVOID Context, CM_NOTIFY_ACTION Action, PCM_NOTIFY_EVENT_DATA EventData, DWORD EventDataSize)
 {
     switch (Action)
     {
@@ -73,7 +73,7 @@ DWORD MyCMInterfaceNotification(HCMNOTIFICATION hNotify, PVOID Context, CM_NOTIF
     default:
         break;
     }
-    return 0;
+    return ERROR_SUCCESS;
 }
 
 class HotPlugManagerWindows : public HotPlugManager


### PR DESCRIPTION
## Changes
<!-- Describe the changes this PR introduces -->
- Adds missing `WINAPI` keyword to callback passed to windows api.

Read more about it at https://learn.microsoft.com/en-us/cpp/cpp/stdcall?view=msvc-170. `WINAPI` is an alias for `__stdcall`, and is what is used in the official examples

## Fixes
<!-- List the GitHub issues this PR resolves -->
- maybe #540

## Checklist
<!-- Put an `x` in the boxes that apply -->
Have you...

- [x] Tested the change acts as expected
- [x] Checked the change doesn't remove or change existing functionality
- [x] Considered how the feature impacts the product and tested around it (not just the happy paths)
- [ ] Where possible, executed the hardware tests on multiple operating systems
