### PR TITLE
bump compilation to ES2019

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "ES2019",
         "strict": true,
         "downlevelIteration": true,
         "noImplicitReturns": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "target": "ES2019",
+        "module": "CommonJS",
         "strict": true,
         "downlevelIteration": true,
         "noImplicitReturns": true,


### PR DESCRIPTION
## Changes

according to node.green, Node v10.8.0 supports ES2019, so switch to that instead of the current ES5.

## Fixes

#604 

## Checklist

- [x] Tested the change acts as expected
- [X] Checked the change doesn't remove or change existing functionality
- [ ] Considered how the feature impacts the product and tested around it (not just the happy paths)
- [ ] Where possible, executed the hardware tests on multiple operating systems
