### PR TITLE
Drop node 10 support and support NAPI 8

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -34,7 +34,7 @@
       'defines': [
         '_FILE_OFFSET_BITS=64',
         '_LARGEFILE_SOURCE',
-        'NAPI_VERSION=6'
+        'NAPI_VERSION=8'
       ],
       'include_dirs+': [
         'src/',

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "2.9.0",
   "main": "dist/index.js",
   "engines": {
-    "node": ">=10.20.0 <11.x || >=12.17.0 <13.0 || >=14.0.0"
+    "node": ">=12.22.0 <13.0 || >=14.17.0"
   },
   "repository": {
     "type": "git",
@@ -72,7 +72,7 @@
   },
   "binary": {
     "napi_versions": [
-      6
+      8
     ]
   }
 }


### PR DESCRIPTION
## Changes
<!-- Describe the changes this PR introduces -->
With reference to discussion in #603 and #605, this PR removes support for node 10 and allows NAPI 8 features.

## Checklist
<!-- Put an `x` in the boxes that apply -->
Have you...

- [x] Tested the change acts as expected
- [x] Checked the change doesn't remove or change existing functionality
- [x] Considered how the feature impacts the product and tested around it (not just the happy paths)
- [x] Where possible, executed the hardware tests on multiple operating systems

Hardware tests run on node (macOS):

- 12.22.7
- 14.18.0
- 16.14.2

cc @mildsunrise 
Would we want a major or minor version bump on release?