### PR TITLE
Fix startPolling to use callback vs over emitted errors.

### DIFF
--- a/test/usb.coffee
+++ b/test/usb.coffee
@@ -187,8 +187,7 @@ describe 'Device', ->
                     throw e
 
                 inEndpoint.on 'end', ->
-                    #console.log("Stream stopped")
-                    done()
+                    assert.equal(n, 100)
 
         describe 'OUT endpoint', ->
             outEndpoint = null

--- a/test/usb.coffee
+++ b/test/usb.coffee
@@ -187,7 +187,7 @@ describe 'Device', ->
                     throw e
 
                 inEndpoint.on 'end', ->
-                    assert.equal(n, 100)
+                    assert.equal(pkts, 100)
 
         describe 'OUT endpoint', ->
             outEndpoint = null

--- a/test/usb.coffee
+++ b/test/usb.coffee
@@ -172,10 +172,12 @@ describe 'Device', ->
             it 'polls the device', (done) ->
                 pkts = 0
 
-                inEndpoint.startPoll 8, 64, (e, b, n) ->
+                inEndpoint.startPoll 8, 64, (e, b, a, c) ->
+                    assert.equal(c, true)
                     assert.ok(e == undefined, e)
-                    assert.equal(n, 100)
+                    assert.equal(pkts, 100)
                     done()
+
                 inEndpoint.on 'data', (d) ->
                     assert.equal d.length, 64
                     pkts++

--- a/test/usb.coffee
+++ b/test/usb.coffee
@@ -172,7 +172,10 @@ describe 'Device', ->
             it 'polls the device', (done) ->
                 pkts = 0
 
-                inEndpoint.startPoll 8, 64
+                inEndpoint.startPoll 8, 64, (e, b, n) ->
+                    assert.ok(e == undefined, e)
+                    assert.equal(n, 100)
+                    done()
                 inEndpoint.on 'data', (d) ->
                     assert.equal d.length, 64
                     pkts++

--- a/test/worker.cjs
+++ b/test/worker.cjs
@@ -8,6 +8,6 @@ if (!device) {
 }
 device.open();
 device.getStringDescriptor(device.deviceDescriptor.iSerialNumber, (_, serial) => {
-    parentPort.postMessage(serial);
+    parentPort?.postMessage(serial);
     device.close();
 });

--- a/test/worker.cjs
+++ b/test/worker.cjs
@@ -2,6 +2,10 @@ const parentPort = require('worker_threads').parentPort
 const findByIds = require('../dist').findByIds;
 
 const device = findByIds(0x59e3, 0x0a23);
+if (!device) {
+    console.error('No test device connected, tests require this device to be present');
+    return;
+}
 device.open();
 device.getStringDescriptor(device.deviceDescriptor.iSerialNumber, (_, serial) => {
     parentPort.postMessage(serial);

--- a/tsc/usb/endpoint.ts
+++ b/tsc/usb/endpoint.ts
@@ -119,7 +119,7 @@ export class InEndpoint extends Endpoint {
                     this.pollActive = false;
                     this.emit('end');
                     if (callback) {
-                        const cancelled = error?.errno !== LIBUSB_TRANSFER_CANCELLED;
+                        const cancelled = error?.errno === LIBUSB_TRANSFER_CANCELLED;
                         callback(cancelled ? undefined : error, buffer, actualLength, cancelled);
                     }
                 }

--- a/tsc/usb/endpoint.ts
+++ b/tsc/usb/endpoint.ts
@@ -107,7 +107,7 @@ export class InEndpoint extends Endpoint {
                     this.stopPoll();
                 }
                 if (callback) {
-                    callback(error, buffer, actualLength)
+                    callback(error, buffer, actualLength);
                 }
             }
 

--- a/tsc/usb/endpoint.ts
+++ b/tsc/usb/endpoint.ts
@@ -104,7 +104,7 @@ export class InEndpoint extends Endpoint {
                 this.emit('data', buffer.slice(0, actualLength));
             } else if (error.errno != LIBUSB_TRANSFER_CANCELLED) {
                 if (this.pollActive) {
-                    this.emit('error', error)
+                    this.emit('error', error);
                     this.stopPoll();
                 }
             }

--- a/tsc/usb/endpoint.ts
+++ b/tsc/usb/endpoint.ts
@@ -104,6 +104,7 @@ export class InEndpoint extends Endpoint {
                 this.emit('data', buffer.slice(0, actualLength));
             } else if (error.errno != LIBUSB_TRANSFER_CANCELLED) {
                 if (this.pollActive) {
+                    this.emit('error', error)
                     this.stopPoll();
                 }
             }

--- a/tsc/usb/endpoint.ts
+++ b/tsc/usb/endpoint.ts
@@ -106,9 +106,6 @@ export class InEndpoint extends Endpoint {
                 if (this.pollActive) {
                     this.stopPoll();
                 }
-                if (callback) {
-                    callback(error, buffer, actualLength);
-                }
             }
 
             if (this.pollActive) {
@@ -121,6 +118,10 @@ export class InEndpoint extends Endpoint {
                     this.pollActive = false;
                     this.emit('end');
                 }
+            }
+
+            if (callback) {
+                callback(error, buffer, actualLength);
             }
         };
 

--- a/tsc/usb/endpoint.ts
+++ b/tsc/usb/endpoint.ts
@@ -119,7 +119,7 @@ export class InEndpoint extends Endpoint {
                     this.pollActive = false;
                     this.emit('end');
                     if (callback) {
-                        const cancelled = error?.errno !== LIBUSB_TRANSFER_CANCELLED
+                        const cancelled = error?.errno !== LIBUSB_TRANSFER_CANCELLED;
                         callback(cancelled ? undefined : error, buffer, actualLength, cancelled);
                     }
                 }

--- a/tsc/usb/endpoint.ts
+++ b/tsc/usb/endpoint.ts
@@ -117,11 +117,10 @@ export class InEndpoint extends Endpoint {
                     this.pollTransfers = [];
                     this.pollActive = false;
                     this.emit('end');
+                    if (callback) {
+                        callback(error, buffer, actualLength);
+                    }
                 }
-            }
-
-            if (callback) {
-                callback(error, buffer, actualLength);
             }
         };
 

--- a/tsc/usb/endpoint.ts
+++ b/tsc/usb/endpoint.ts
@@ -96,15 +96,18 @@ export class InEndpoint extends Endpoint {
      * The device must be open to use this method.
      * @param nTransfers
      * @param transferSize
+     * @param callback
      */
-    public startPoll(nTransfers?: number, transferSize?: number, _callback?: (error: LibUSBException | undefined, buffer: Buffer, actualLength: number) => void): Transfer[] {
+    public startPoll(nTransfers?: number, transferSize?: number, callback?: (error: LibUSBException | undefined, buffer: Buffer, actualLength: number) => void): Transfer[] {
         const transferDone = (error: LibUSBException | undefined, transfer: Transfer, buffer: Buffer, actualLength: number) => {
             if (!error) {
                 this.emit('data', buffer.slice(0, actualLength));
             } else if (error.errno != LIBUSB_TRANSFER_CANCELLED) {
-                this.emit('error', error);
                 if (this.pollActive) {
                     this.stopPoll();
+                }
+                if (callback) {
+                    callback(error, buffer, actualLength)
                 }
             }
 

--- a/tsc/usb/endpoint.ts
+++ b/tsc/usb/endpoint.ts
@@ -103,7 +103,9 @@ export class InEndpoint extends Endpoint {
                 this.emit('data', buffer.slice(0, actualLength));
             } else if (error.errno != LIBUSB_TRANSFER_CANCELLED) {
                 this.emit('error', error);
-                this.stopPoll();
+                if (this.pollActive) {
+                    this.stopPoll();
+                }
             }
 
             if (this.pollActive) {


### PR DESCRIPTION
## Changes
- Use callback in `startPoll` which is not being used vs emitting errors blindly

## Fixes
- Fixed #630 by utilizing the callback which is not being used vs emitting errors

## Checklist

- [x] Tested the change acts as expected
- [x] Checked the change doesn't remove or change existing functionality
- [x] Considered how the feature impacts the product and tested around it (not just the happy paths)
- [x] Where possible, executed the hardware tests on multiple operating systems

The only thing this impacts is most people likely never used the callback, as it was never utilized, however it seems like it was meant to be. This means people (like myself) likely are adding an error catching for the emits. Though this is what causes the issues with FATAL ERRORS.
