### PR TITLE
Make close safe to call multiple times

### DIFF
--- a/src/device.cc
+++ b/src/device.cc
@@ -203,9 +203,11 @@ Napi::Value Device::Open(const Napi::CallbackInfo& info) {
 Napi::Value Device::Close(const Napi::CallbackInfo& info) {
     ENTER_METHOD(Device, 0);
     if (self->canClose()){
-        libusb_close(self->device_handle);
-        self->device_handle = NULL;
-        completionQueue.stop();
+        if (self->device_handle){
+            libusb_close(self->device_handle);
+            self->device_handle = NULL;
+            completionQueue.stop();
+        }
     }else{
         THROW_ERROR("Can't close device with a pending request");
     }


### PR DESCRIPTION
## Fixes
- Make it safe to call `device.close()` multiple times.

While the [inline documentation](https://github.com/node-usb/node-usb/blob/d07662b36e408a49d7011c2467569edc57e5575b/tsc/usb/device.ts#L82C11-L82C11) is clear that the device must be open to call `close()`, it's an easy mistake to make to call close multiple times. This will appear to work most of the time, but if the `Napi::ThreadSafeFunction` in `completionQueue` has been destroyed by Node, then the Node process will crash (with SIGABRT in my case). This means the crashes may be intermittent and hard to root-cause.

The proposed change also makes `Device::Open()` and `Device::Close()` more similiar since `Open()` checks `if (!self->device_handle)` while `Close()` didn't check `if (self->device_handle)`.

## Context
- [device.close](https://github.com/node-usb/node-usb/blob/master/tsc/usb/device.ts#L79-L87)
- [Device::Close](https://github.com/node-usb/node-usb/blob/master/src/device.cc#L203-L213)
- [UVQueue::stop](https://github.com/node-usb/node-usb/blob/master/src/uv_async_queue.h#L18-L20)
- [TypedThreadSafeFunction::Release](https://github.com/nodejs/node-addon-api/blob/main/napi-inl.h#L5631-L5637)
- [napi_release_threadsafe_function](https://nodejs.org/api/n-api.html#napi_release_threadsafe_function)

## Program to reproduce
```
const usb = require('usb');

const device = usb.findByIds(0x2b04, 0xc00c); // change to a device connected to your machine

device.open();
device.close();
setTimeout(() => {
	device.close(); // without the fix, Node crashes when this is called
}, 1000); // arbitrary delay to let Node clean up the TypedThreadSafeFunction
```

## Checklist

- [X] Tested the change acts as expected
- [X] Checked the change doesn't remove or change existing functionality
- [X] Considered how the feature impacts the product and tested around it (not just the happy paths)
- [ ] Where possible, executed the hardware tests on multiple operating systems
