### PR TITLE
Throw error when transferring and device closed

### DIFF
--- a/test/webusb.coffee
+++ b/test/webusb.coffee
@@ -171,6 +171,15 @@ describe 'Alternates', ->
     after ->
         device.close()
 
+describe 'Throwing Transfers', ->
+    device = null
+
+    before ->
+        device = await webusb.requestDevice({ filters: [{ vendorId: 0x59e3 }] });
+
+    it 'should fail transfer unless opened', ->
+        assert.rejects(device.transferIn(1, 64), 'The device must be opened first')
+
 describe 'Transfers', ->
     device = null
     b = Uint8Array.from([0x30...0x40]).buffer

--- a/tsc/webusb/webusb-device.ts
+++ b/tsc/webusb/webusb-device.ts
@@ -206,6 +206,7 @@ export class WebUSBDevice implements USBDevice {
 
     public async controlTransferIn(setup: USBControlTransferParameters, length: number): Promise<USBInTransferResult> {
         try {
+            this.checkDeviceOpen();
             const type = this.controlTransferParamsToType(setup, usb.LIBUSB_ENDPOINT_IN);
             const controlTransfer = promisify(this.device.controlTransfer).bind(this.device);
             const result = await controlTransfer(type, setup.request, setup.value, setup.index, length);
@@ -233,6 +234,7 @@ export class WebUSBDevice implements USBDevice {
 
     public async controlTransferOut(setup: USBControlTransferParameters, data?: ArrayBuffer): Promise<USBOutTransferResult> {
         try {
+            this.checkDeviceOpen();
             const type = this.controlTransferParamsToType(setup, usb.LIBUSB_ENDPOINT_OUT);
             const controlTransfer = promisify(this.device.controlTransfer).bind(this.device);
             const buffer = data ? Buffer.from(data) : Buffer.alloc(0);
@@ -266,6 +268,7 @@ export class WebUSBDevice implements USBDevice {
 
     public async transferIn(endpointNumber: number, length: number): Promise<USBInTransferResult> {
         try {
+            this.checkDeviceOpen();
             const endpoint = this.getEndpoint(endpointNumber | usb.LIBUSB_ENDPOINT_IN) as InEndpoint;
             const transfer = promisify(endpoint.transfer).bind(endpoint);
             const result = await transfer(length);
@@ -293,6 +296,7 @@ export class WebUSBDevice implements USBDevice {
 
     public async transferOut(endpointNumber: number, data: ArrayBuffer): Promise<USBOutTransferResult> {
         try {
+            this.checkDeviceOpen();
             const endpoint = this.getEndpoint(endpointNumber | usb.LIBUSB_ENDPOINT_OUT) as OutEndpoint;
             const transfer = promisify(endpoint.transfer).bind(endpoint);
             const buffer = Buffer.from(data);
@@ -481,6 +485,12 @@ export class WebUSBDevice implements USBDevice {
             await release();
         } catch (error) {
             throw new Error(`releaseInterface error: ${error}`);
+        }
+    }
+
+    private checkDeviceOpen(): void {
+        if (!this.opened) {
+            throw new Error('The device must be opened first');
         }
     }
 }


### PR DESCRIPTION
## Changes
<!-- Describe the changes this PR introduces -->
- Added check in WebUSB API for device to be opened before transferring

## Fixes
<!-- List the GitHub issues this PR resolves -->
- Fixes #714

## Checklist
<!-- Put an `x` in the boxes that apply -->
Have you...

- [x] Tested the change acts as expected
- [x] Checked the change doesn't remove or change existing functionality
- [x] Considered how the feature impacts the product and tested around it (not just the happy paths)
- [x] Where possible, executed the hardware tests on multiple operating systems
