### PR TITLE
Patches WebUSBDevice to force reconfiguration deviceClass 0xff

### DIFF
--- a/tsc/webusb/webusb-device.ts
+++ b/tsc/webusb/webusb-device.ts
@@ -353,6 +353,11 @@ export class WebUSBDevice implements USBDevice {
             if (!this.opened) {
                 this.device.open();
             }
+            if (this.opened && this.deviceClass === 0xff && this.device.interfaces && !this.device.interfaces.length) {
+                this.device.close();
+                this.device.open(false);
+                this.device.setConfiguration(1);
+            }
 
             this.manufacturerName = await this.getStringDescriptor(this.device.deviceDescriptor.iManufacturer);
             this.productName = await this.getStringDescriptor(this.device.deviceDescriptor.iProduct);


### PR DESCRIPTION

## Changes

Tries to detect if deviceClass 0xff devices have not been configured by default (macOS) and then uses the workaround to set configuration manually.

Tested with Sony MDS-JB980 hardware through netmd-js library using node-usb WebUSB on macOS.

## Fixes
- #61 - So that it works for WebUSB without hacks prior using WebUSB

## Checklist

- [X] Tested the change acts as expected
- [X] Checked the change doesn't remove or change existing functionality
- [x] Considered how the feature impacts the product and tested around it (not just the happy paths)
- [ ] Where possible, executed the hardware tests on multiple operating systems
