### PR TITLE
Explicitly set configuration for vendor-specific devices on macos

### DIFF
--- a/tsc/usb/device.ts
+++ b/tsc/usb/device.ts
@@ -66,10 +66,11 @@ export class ExtendedDevice {
      */
     public open(this: usb.Device, defaultConfig = true): void {
         this.__open();
+        // The presence of interfaces is used to determine if the device is open
+        this.interfaces = [];
         if (defaultConfig === false) {
             return;
         }
-        this.interfaces = [];
         const len = this.configDescriptor ? this.configDescriptor.interfaces.length : 0;
         for (let i = 0; i < len; i++) {
             this.interfaces[i] = new Interface(this, i);

--- a/tsc/webusb/webusb-device.ts
+++ b/tsc/webusb/webusb-device.ts
@@ -1,6 +1,7 @@
 import * as usb from '../usb';
 import { promisify } from 'util';
 import { Endpoint, InEndpoint, OutEndpoint } from '../usb/endpoint';
+import { platform } from 'os';
 
 const LIBUSB_TRANSFER_TYPE_MASK = 0x03;
 const ENDPOINT_NUMBER_MASK = 0x7f;
@@ -352,6 +353,12 @@ export class WebUSBDevice implements USBDevice {
         try {
             if (!this.opened) {
                 this.device.open();
+
+                // Explicitly set configuration for vendor-specific devices on macos
+                // https://github.com/node-usb/node-usb/issues/61
+                if (this.deviceClass === 0xff && platform() === 'darwin') {
+                    await this.setConfigurationAsync(1);
+                }
             }
 
             this.manufacturerName = await this.getStringDescriptor(this.device.deviceDescriptor.iManufacturer);


### PR DESCRIPTION
## Changes
<!-- Describe the changes this PR introduces -->

- Explicitly set configuration for vendor-specific devices on macos
- Always initialise interfaces array when device opened

This is an alternative to #732 

## Fixes
<!-- List the GitHub issues this PR resolves -->
- #61 

- [ ] Tested the change acts as expected
- [ ] Checked the change doesn't remove or change existing functionality
- [ ] Considered how the feature impacts the product and tested around it (not just the happy paths)
- [ ] Where possible, executed the hardware tests on multiple operating systems
