### PR TITLE
Roll back prebuildify to 5.x.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "prebuildify"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "eslint": "^8.29.0",
     "mocha": "^10.1.0",
     "node-gyp": "^10.0.1",
-    "prebuildify": "^6.0.0",
+    "prebuildify": "^5.0.1",
     "prebuildify-ci": "^1.0.5",
     "prebuildify-cross": "^5.0.0",
     "typedoc": "^0.22.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2901,10 +2901,10 @@ prebuildify-cross@^5.0.0:
     tar-fs "^2.0.0"
     unixify "^1.0.0"
 
-prebuildify@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/prebuildify/-/prebuildify-6.0.0.tgz#da3dba61e0e9fad7e63beaf7332b286ae6d8a562"
-  integrity sha512-DEvK4C3tcimIp7Pzqbs036n9i6CTKGp1XVEpMnr4wV3enKU5sBogPP+lP3KZw7993i42bXnsd5eIxAXQ566Cqw==
+prebuildify@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/prebuildify/-/prebuildify-5.0.1.tgz#e10bb6e4986c18909185704c806cc06976c30478"
+  integrity sha512-vXpKLfIEsDCqMJWVIoSrUUBJQIuAk9uHAkLiGJuTdXdqKSJ10sHmWeuNCDkIoRFTV1BDGYMghHVmDFP8NfkA2Q==
   dependencies:
     execspawn "^1.0.1"
     minimist "^1.2.5"


### PR DESCRIPTION
## Changes
<!-- Describe the changes this PR introduces -->

- Temporary rollback to prebuildify 5.x.x

## Fixes
<!-- List the GitHub issues this PR resolves -->

As described in #743 , [this change](https://github.com/prebuild/prebuildify/commit/7b6dcbd0860a82db8804079ba55663affd9ae555) introduced naming compatibility issues.

This rolls back the version of prebuildify until [this issue](https://github.com/prebuild/prebuildify/issues/79) is fixed in https://github.com/prebuild/prebuildify/pull/80 (props to @strazzere)

## Checklist
<!-- Put an `x` in the boxes that apply -->
Have you...

- [ ] Tested the change acts as expected
- [ ] Checked the change doesn't remove or change existing functionality
- [ ] Considered how the feature impacts the product and tested around it (not just the happy paths)
- [ ] Where possible, executed the hardware tests on multiple operating systems
