### PR TITLE
getDeviceList() returns stale devices

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,6 +1,6 @@
 {
   'variables': {
-    'use_udev%': 1,
+    'use_udev%': 0,
     'use_system_libusb%': 'false'
   },
   'dependencies': [

--- a/libusb.gypi
+++ b/libusb.gypi
@@ -1,6 +1,6 @@
 {
   'variables': {
-    'use_udev%': 1,
+    'use_udev%': 0,
     'use_system_libusb%': 'false',
     'module_name': 'usb_bindings',
     'module_path': './src/binding'


### PR DESCRIPTION
## Changes
<!-- Describe the changes this PR introduces -->
Compiling libusb without udev fixes the problem.
I tried running [libusbTest](https://github.com/JonathanLeeIFX/libusbTest) from https://github.com/node-usb/node-usb/issues/803#issuecomment-2389707705 and it didn't work either - unless I compiled libusb without udev.

## Fixes
- #579 

## Checklist
<!-- Put an `x` in the boxes that apply -->
Have you...

- [x] Tested the change acts as expected
- [x] Checked the change doesn't remove or change existing functionality
- [x] Considered how the feature impacts the product and tested around it (not just the happy paths)
- [ ] Where possible, executed the hardware tests on multiple operating systems
