### PR TITLE
Catch no device error when getting config descriptors

### DIFF
--- a/tsc/usb/device.ts
+++ b/tsc/usb/device.ts
@@ -31,7 +31,11 @@ export class ExtendedDevice {
             return (this as unknown as usb.Device).__getConfigDescriptor();
         } catch (e) {
             // Check descriptor exists
-            if ((e as usb.LibUSBException).errno === usb.LIBUSB_ERROR_NOT_FOUND) {
+            const errno = (e as usb.LibUSBException).errno;
+            if (
+                errno === usb.LIBUSB_ERROR_NOT_FOUND ||
+                errno === usb.LIBUSB_ERROR_NO_DEVICE
+            ) {
                 return undefined;
             }
             throw e;
@@ -46,7 +50,11 @@ export class ExtendedDevice {
             return (this as unknown as usb.Device).__getAllConfigDescriptors();
         } catch (e) {
             // Check descriptors exist
-            if ((e as usb.LibUSBException).errno === usb.LIBUSB_ERROR_NOT_FOUND) {
+            const errno = (e as usb.LibUSBException).errno;
+            if (
+                errno === usb.LIBUSB_ERROR_NOT_FOUND ||
+                errno === usb.LIBUSB_ERROR_NO_DEVICE
+            ) {
                 return [];
             }
             throw e;


### PR DESCRIPTION
## Changes
<!-- Describe the changes this PR introduces -->
When you release an interface it refreshes it inside a callback:
 ![image](https://github.com/user-attachments/assets/9ee78953-5951-4628-9514-06d7753e2e1c)

`refresh` calls `get configDescriptor` which when the device is disconnected can throw `LIBUSB_ERROR_NO_DEVICE` .

Because this is done inside a callback I can't catch it in a try catch and it crashes the program: 
![image](https://github.com/user-attachments/assets/2173add1-d30e-4cf9-b0f4-64f38a101f03)


## Fixes
<!-- List the GitHub issues this PR resolves -->
-

## Checklist
<!-- Put an `x` in the boxes that apply -->
Have you...

- [x] Tested the change acts as expected
- [x] Checked the change doesn't remove or change existing functionality
- [x] Considered how the feature impacts the product and tested around it (not just the happy paths)
- [ ] Where possible, executed the hardware tests on multiple operating systems
