### PR TITLE
optional env var to override module path

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/tsc/usb/bindings.ts
+++ b/tsc/usb/bindings.ts
@@ -6,7 +6,7 @@ import { join } from 'path';
 import type { DeviceDescriptor, ConfigDescriptor, BosDescriptor } from './descriptors';
 
 /* eslint-disable @typescript-eslint/no-var-requires */
-const usb = require('node-gyp-build')(join(__dirname, '..', '..'));
+const usb = require('node-gyp-build')(process.env.NODE_USB_PATH || join(__dirname, '..', '..'));
 module.exports = usb;
 
 /**


### PR DESCRIPTION
In my use of this package, I'm using `@vercel/ncc` to build my backend into a single file. Because of that, `join(__dirname, '..', '..')` is no longer accurate for where `node-gyp-build` needs to look for the binary. I have included an optional var that can be used to override the path. This seems to be standard for other binaries I'm using in my project. 

## Changes
<!-- Describe the changes this PR introduces -->
- Introduces a new env var `NODE_USB_PATH` where one can override the expected path of the module for node-gyp-build to look in.

## Checklist
<!-- Put an `x` in the boxes that apply -->
Have you...

- [x] Tested the change acts as expected
- [x] Checked the change doesn't remove or change existing functionality
- [x] Considered how the feature impacts the product and tested around it (not just the happy paths)
- [x] Where possible, executed the hardware tests on multiple operating systems
