### PR TITLE
Add device.setAutoDetachKernelDriver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.15.0] - 2025-02-21
+
+### Added
+- Added support for `device.setAutoDetachKernelDriver` and set this to true for all devices in the WebUSB API - [`859`](https://github.com/node-usb/node-usb/pull/859) ([Rob Moran](https://github.com/thegecko))
+
 ## [2.14.0] - 2024-09-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -411,6 +411,9 @@ Timeout in milliseconds to use for control transfers.
 #### .reset(callback(error))
 Performs a reset of the device. Callback is called when complete.
 
+#### .setAutoDetachKernelDriver(enable)
+Enable/disable libusb's automatic kernel driver detachment (default true)
+
 ### Interface
 
 #### .endpoint(address)

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ Timeout in milliseconds to use for control transfers.
 Performs a reset of the device. Callback is called when complete.
 
 #### .setAutoDetachKernelDriver(enable)
-Enable/disable libusb's automatic kernel driver detachment (default true)
+Enable/disable libusb's automatic kernel driver detachment (defaults to true in the WebUSB API)
 
 ### Interface
 

--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ Returns `false` if a kernel driver is not active; `true` if active.
 
 #### .detachKernelDriver()
 Detaches the kernel driver from the interface.
+If a `LIBUSB_ERROR_ACCESS` error is raised, you may need to execute this with elevated privileges.
 
 #### .attachKernelDriver()
 Re-attaches the kernel driver for the interface.

--- a/binding.gyp
+++ b/binding.gyp
@@ -18,7 +18,7 @@
       'xcode_settings': {
         'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
         'CLANG_CXX_LIBRARY': 'libc++',
-        'MACOSX_DEPLOYMENT_TARGET': '10.7'
+        'MACOSX_DEPLOYMENT_TARGET': '10.10'
       },
       'msvs_settings': {
         'VCCLCompilerTool': {
@@ -72,7 +72,7 @@
                 '-arch arm64'
               ],
               'SDKROOT': 'macosx',
-              'MACOSX_DEPLOYMENT_TARGET': '10.7'
+              'MACOSX_DEPLOYMENT_TARGET': '10.10'
             }
           }],
           ['OS!="win"', {

--- a/binding.gyp
+++ b/binding.gyp
@@ -68,6 +68,7 @@
               'OTHER_LDFLAGS': [
                 '-framework', 'CoreFoundation',
                 '-framework', 'IOKit',
+                '-framework', 'Security',
                 '-arch x86_64',
                 '-arch arm64'
               ],

--- a/binding.gyp
+++ b/binding.gyp
@@ -18,7 +18,7 @@
       'xcode_settings': {
         'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
         'CLANG_CXX_LIBRARY': 'libc++',
-        'MACOSX_DEPLOYMENT_TARGET': '10.10'
+        'MACOSX_DEPLOYMENT_TARGET': '10.7'
       },
       'msvs_settings': {
         'VCCLCompilerTool': {
@@ -73,7 +73,7 @@
                 '-arch arm64'
               ],
               'SDKROOT': 'macosx',
-              'MACOSX_DEPLOYMENT_TARGET': '10.10'
+              'MACOSX_DEPLOYMENT_TARGET': '10.7'
             }
           }],
           ['OS!="win"', {

--- a/libusb.gypi
+++ b/libusb.gypi
@@ -118,7 +118,7 @@
               '-arch arm64'
             ],
             'CLANG_CXX_LIBRARY': 'libc++',
-            'MACOSX_DEPLOYMENT_TARGET': '10.10'
+            'MACOSX_DEPLOYMENT_TARGET': '10.7'
           }
         }],
         [ 'OS == "win"', {

--- a/libusb.gypi
+++ b/libusb.gypi
@@ -118,7 +118,7 @@
               '-arch arm64'
             ],
             'CLANG_CXX_LIBRARY': 'libc++',
-            'MACOSX_DEPLOYMENT_TARGET': '10.7'
+            'MACOSX_DEPLOYMENT_TARGET': '10.10'
           }
         }],
         [ 'OS == "win"', {

--- a/src/device.cc
+++ b/src/device.cc
@@ -320,6 +320,15 @@ Napi::Value Device::AttachKernelDriver(const Napi::CallbackInfo& info) {
     return env.Undefined();
 }
 
+Napi::Value Device::SetAutoDetachKernelDriver(const Napi::CallbackInfo& info) {
+    ENTER_METHOD(Device, 1);
+    CHECK_OPEN();
+    int enable;
+    INT_ARG(enable, 0);
+    CHECK_USB(libusb_set_auto_detach_kernel_driver(self->device_handle, enable));
+    return env.Undefined();
+}
+
 Napi::Value Device::ClaimInterface(const Napi::CallbackInfo& info) {
     ENTER_METHOD(Device, 1);
     CHECK_OPEN();
@@ -419,6 +428,7 @@ Napi::Object Device::Init(Napi::Env env, Napi::Object exports) {
             Device::InstanceMethod("__isKernelDriverActive", &Device::IsKernelDriverActive),
             Device::InstanceMethod("__detachKernelDriver", &Device::DetachKernelDriver),
             Device::InstanceMethod("__attachKernelDriver", &Device::AttachKernelDriver),
+            Device::InstanceMethod("__setAutoDetachKernelDriver", &Device::SetAutoDetachKernelDriver),
         });
     exports.Set("Device", func);
 

--- a/src/node_usb.h
+++ b/src/node_usb.h
@@ -57,6 +57,7 @@ struct Device: public Napi::ObjectWrap<Device> {
     Napi::Value IsKernelDriverActive(const Napi::CallbackInfo& info);
     Napi::Value DetachKernelDriver(const Napi::CallbackInfo& info);
     Napi::Value AttachKernelDriver(const Napi::CallbackInfo& info);
+    Napi::Value SetAutoDetachKernelDriver(const Napi::CallbackInfo& info);
 
     Napi::Value ClaimInterface(const Napi::CallbackInfo& info);
     Napi::Value SetInterface(const Napi::CallbackInfo& info);

--- a/tsc/usb/bindings.ts
+++ b/tsc/usb/bindings.ts
@@ -104,6 +104,7 @@ export declare class Device {
     __detachKernelDriver(addr: number): void;
     __attachKernelDriver(addr: number): void;
     __isKernelDriverActive(addr: number): boolean;
+    __setAutoDetachKernelDriver(enable: number): void;
 
     /**
     * Performs a reset of the device. Callback is called when complete.

--- a/tsc/usb/device.ts
+++ b/tsc/usb/device.ts
@@ -74,7 +74,6 @@ export class ExtendedDevice {
      */
     public open(this: usb.Device, defaultConfig = true): void {
         this.__open();
-        this.setAutoDetachKernelDriver(true);
 
         // The presence of interfaces is used to determine if the device is open
         this.interfaces = [];

--- a/tsc/usb/device.ts
+++ b/tsc/usb/device.ts
@@ -74,6 +74,8 @@ export class ExtendedDevice {
      */
     public open(this: usb.Device, defaultConfig = true): void {
         this.__open();
+        this.setAutoDetachKernelDriver(true);
+
         // The presence of interfaces is used to determine if the device is open
         this.interfaces = [];
         if (defaultConfig === false) {
@@ -116,6 +118,16 @@ export class ExtendedDevice {
                 callback.call(this, error);
             }
         });
+    }
+
+    /**
+     * Enable/disable libusb's automatic kernel driver detachment
+     * When this is enabled libusb will automatically detach the kernel driver on an interface when claiming the interface, and attach it when releasing the interface
+     *
+     * The device must be open to use this method.
+     */
+    public setAutoDetachKernelDriver(enable: boolean): void {
+        return (this as unknown as usb.Device).__setAutoDetachKernelDriver(enable ? 1 : 0);
     }
 
     /**

--- a/tsc/webusb/index.ts
+++ b/tsc/webusb/index.ts
@@ -25,6 +25,11 @@ export interface USBOptions {
      * Optional timeout (in milliseconds) to use for the device control transfers
      */
     deviceTimeout?: number;
+
+    /**
+     * Optional flag to enable/disable automatic kernal driver detaching (defaults to true)
+     */
+    autoDetachKernelDriver?: boolean;
 }
 
 /**
@@ -267,7 +272,7 @@ export class WebUSB implements USB {
             }
 
             try {
-                const webDevice = await WebUSBDevice.createInstance(device);
+                const webDevice = await WebUSBDevice.createInstance(device, this.options.autoDetachKernelDriver);
                 this.knownDevices.set(device, webDevice);
             } catch {
                 // Ignore creation issues as this may be a system device

--- a/tsc/webusb/webusb-device.ts
+++ b/tsc/webusb/webusb-device.ts
@@ -89,6 +89,7 @@ export class WebUSBDevice implements USBDevice {
             }
 
             this.device.open();
+            this.device.setAutoDetachKernelDriver(true);
         } catch (error) {
             throw new Error(`open error: ${error}`);
         }

--- a/tsc/webusb/webusb-device.ts
+++ b/tsc/webusb/webusb-device.ts
@@ -12,8 +12,8 @@ const ENDPOINT_HALT = 0x00;
  * Wrapper to make a node-usb device look like a webusb device
  */
 export class WebUSBDevice implements USBDevice {
-    public static async createInstance(device: usb.Device): Promise<WebUSBDevice> {
-        const instance = new WebUSBDevice(device);
+    public static async createInstance(device: usb.Device, autoDetachKernelDriver = true): Promise<WebUSBDevice> {
+        const instance = new WebUSBDevice(device, autoDetachKernelDriver);
         await instance.initialize();
         return instance;
     }
@@ -47,7 +47,7 @@ export class WebUSBDevice implements USBDevice {
     private resetAsync: () => Promise<void>;
     private getStringDescriptorAsync: (desc_index: number) => Promise<string | undefined>;
 
-    private constructor(private device: usb.Device) {
+    private constructor(private device: usb.Device, private autoDetachKernelDriver: boolean) {
         const usbVersion = this.decodeVersion(device.deviceDescriptor.bcdUSB);
         this.usbVersionMajor = usbVersion.major;
         this.usbVersionMinor = usbVersion.minor;
@@ -89,7 +89,7 @@ export class WebUSBDevice implements USBDevice {
             }
 
             this.device.open();
-            this.device.setAutoDetachKernelDriver(true);
+            this.device.setAutoDetachKernelDriver(this.autoDetachKernelDriver);
         } catch (error) {
             throw new Error(`open error: ${error}`);
         }


### PR DESCRIPTION
## Changes
<!-- Describe the changes this PR introduces -->
- Added support for `device.setAutoDetachKernelDriver` and set this to true for all devices in the WebUSB API

## Fixes
<!-- List the GitHub issues this PR resolves -->
- #857 

## Checklist
<!-- Put an `x` in the boxes that apply -->
Have you...

- [x] Tested the change acts as expected
- [x] Checked the change doesn't remove or change existing functionality
- [x] Considered how the feature impacts the product and tested around it (not just the happy paths)
- [x] Where possible, executed the hardware tests on multiple operating systems
